### PR TITLE
feat(ui): implement dashboard — interview list, cards, API (Plan 4)

### DIFF
--- a/app/api/interviews/route.ts
+++ b/app/api/interviews/route.ts
@@ -1,0 +1,28 @@
+// Implements #8: Dashboard API — GET user's interviews
+import { NextResponse } from 'next/server';
+import { getAuthUser } from '@/lib/auth';
+import { createServerSupabaseClient } from '@/lib/supabase-server';
+
+export async function GET() {
+  try {
+    const user = await getAuthUser();
+    const supabase = createServerSupabaseClient();
+
+    const { data, error } = await supabase
+      .from('interviews')
+      .select('id, participant_name, topic, target_user, status, duration_seconds, created_at, updated_at')
+      .eq('user_id', user.id)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      return NextResponse.json({ error: 'Failed to fetch interviews' }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (err) {
+    if (err instanceof Error && err.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,44 +1,41 @@
-'use client';
-
-import { useAuth } from '@/lib/hooks/use-auth';
+// Implements #8: Dashboard page (server component)
+import { redirect } from 'next/navigation';
+import { getAuthUser } from '@/lib/auth';
+import { createServerSupabaseClient } from '@/lib/supabase-server';
 import { ThemeToggle } from '@/components/ui/theme-toggle';
-import { Button } from '@/components/ui/button';
-import { Card } from '@/components/ui/card';
-import { useRouter } from 'next/navigation';
+import { UserMenu } from '@/components/ui/user-menu';
+import { DashboardView } from '@/components/interview/dashboard-view';
 
-export default function DashboardPage() {
-  const { user, signOut } = useAuth();
-  const router = useRouter();
+export default async function DashboardPage() {
+  let user;
+  try {
+    user = await getAuthUser();
+  } catch {
+    redirect('/login');
+  }
 
-  const handleSignOut = async () => {
-    await signOut();
-    router.push('/login');
-  };
+  const supabase = createServerSupabaseClient();
+
+  const { data: interviews, error } = await supabase
+    .from('interviews')
+    .select('id, participant_name, topic, target_user, status, duration_seconds, created_at, updated_at')
+    .eq('user_id', user.id)
+    .order('created_at', { ascending: false });
 
   return (
-    <div className="min-h-screen p-8">
-      <div className="mx-auto max-w-4xl space-y-6">
-        <div className="flex items-center justify-between">
-          <h1 className="font-heading text-2xl font-bold">Dashboard</h1>
+    <div className="min-h-screen p-6 sm:p-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <header className="flex items-center justify-between">
+          <h1 className="font-heading text-2xl font-bold text-[var(--text-primary)]">
+            Dashboard
+          </h1>
           <div className="flex items-center gap-3">
             <ThemeToggle />
-            <Button variant="ghost" size="sm" onClick={handleSignOut}>
-              Sign Out
-            </Button>
+            <UserMenu />
           </div>
-        </div>
+        </header>
 
-        <Card>
-          <p className="text-sm text-text-muted">
-            Signed in as <strong>{user?.email ?? 'loading...'}</strong>
-          </p>
-        </Card>
-
-        <Card>
-          <p className="text-text-muted">
-            No interviews yet. The interview flow will be built in Plan 3.
-          </p>
-        </Card>
+        <DashboardView interviews={error ? [] : interviews ?? []} />
       </div>
     </div>
   );

--- a/components/interview/dashboard-view.tsx
+++ b/components/interview/dashboard-view.tsx
@@ -1,0 +1,78 @@
+// Implements #8: Dashboard view — interview grid, empty state, New Interview FAB
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { Plus, MessageSquare } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { InterviewCard } from './interview-card';
+import type { InterviewStatus } from '@/lib/constants';
+
+interface InterviewRow {
+  id: string;
+  participant_name: string;
+  topic: string;
+  target_user: string;
+  status: string;
+  duration_seconds: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+interface DashboardViewProps {
+  interviews: InterviewRow[];
+}
+
+export function DashboardView({ interviews }: DashboardViewProps) {
+  const router = useRouter();
+
+  if (interviews.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center">
+        <div className="mb-4 rounded-full bg-primary/10 p-4">
+          <MessageSquare className="h-8 w-8 text-primary" aria-hidden="true" />
+        </div>
+        <h2 className="font-heading text-lg font-semibold text-[var(--text-primary)]">
+          No interviews yet
+        </h2>
+        <p className="mt-2 max-w-sm text-sm text-[var(--text-secondary)] font-body">
+          Start your first Mom Test interview to validate your business idea with real user insights.
+        </p>
+        <Button
+          className="mt-6"
+          onClick={() => router.push('/interview/new')}
+          icon={<Plus className="h-4 w-4" />}
+          aria-label="Start new interview"
+        >
+          New Interview
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {interviews.map((interview) => (
+          <InterviewCard
+            key={interview.id}
+            id={interview.id}
+            participantName={interview.participant_name}
+            topic={interview.topic}
+            status={interview.status as InterviewStatus}
+            durationSeconds={interview.duration_seconds}
+            createdAt={interview.created_at}
+          />
+        ))}
+      </div>
+
+      {/* Floating Action Button */}
+      <button
+        onClick={() => router.push('/interview/new')}
+        className="fixed bottom-6 right-6 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-white shadow-lg transition-all duration-200 hover:bg-primary-dark hover:shadow-xl hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-primary/50 focus:ring-offset-2 cursor-pointer"
+        aria-label="Start new interview"
+      >
+        <Plus className="h-6 w-6" />
+      </button>
+    </div>
+  );
+}

--- a/components/interview/interview-card.tsx
+++ b/components/interview/interview-card.tsx
@@ -1,0 +1,91 @@
+// Implements #8: Interview card for dashboard grid
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { format } from 'date-fns';
+import { Play, CheckCircle, BarChart3, Clock } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import type { InterviewStatus } from '@/lib/constants';
+
+interface InterviewCardProps {
+  id: string;
+  participantName: string;
+  topic: string;
+  status: InterviewStatus;
+  durationSeconds: number | null;
+  createdAt: string;
+}
+
+const statusConfig: Record<InterviewStatus, { label: string; variant: 'active' | 'completed' | 'analyzed'; icon: React.ReactNode }> = {
+  active: { label: 'Active', variant: 'active', icon: <Play className="h-3.5 w-3.5" /> },
+  completed: { label: 'Completed', variant: 'completed', icon: <CheckCircle className="h-3.5 w-3.5" /> },
+  analyzed: { label: 'Analyzed', variant: 'analyzed', icon: <BarChart3 className="h-3.5 w-3.5" /> },
+};
+
+function formatDuration(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${mins}:${String(secs).padStart(2, '0')}`;
+}
+
+export function InterviewCard({
+  id,
+  participantName,
+  topic,
+  status,
+  durationSeconds,
+  createdAt,
+}: InterviewCardProps) {
+  const router = useRouter();
+  const config = statusConfig[status];
+
+  const handleClick = () => {
+    if (status === 'active') {
+      router.push(`/interview/${id}`);
+    } else if (status === 'analyzed') {
+      router.push(`/dashboard/${id}/report`);
+    }
+  };
+
+  return (
+    <Card
+      hover
+      padding="md"
+      onClick={handleClick}
+      role="button"
+      tabIndex={0}
+      aria-label={`Interview with ${participantName} — ${config.label}`}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          handleClick();
+        }
+      }}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <h3 className="font-heading text-base font-semibold text-[var(--text-primary)] truncate">
+            {participantName}
+          </h3>
+          <p className="mt-1 text-sm text-[var(--text-secondary)] font-body line-clamp-2">
+            {topic}
+          </p>
+        </div>
+        <Badge variant={config.variant} icon={config.icon}>
+          {config.label}
+        </Badge>
+      </div>
+
+      <div className="mt-4 flex items-center gap-4 text-xs text-[var(--text-muted)] font-body">
+        <span>{format(new Date(createdAt), 'MMM d, yyyy')}</span>
+        {durationSeconds != null && (
+          <span className="flex items-center gap-1">
+            <Clock className="h-3 w-3" aria-hidden="true" />
+            {formatDuration(durationSeconds)}
+          </span>
+        )}
+      </div>
+    </Card>
+  );
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,13 @@ const config = {
     '^.+\\.tsx?$': [
       'ts-jest',
       {
-        tsconfig: 'tsconfig.json',
+        tsconfig: {
+          jsx: 'react-jsx',
+          module: 'esnext',
+          moduleResolution: 'bundler',
+          esModuleInterop: true,
+          paths: { '@/*': ['./*'] },
+        },
       },
     ],
   },

--- a/tests/components/dashboard-view.test.tsx
+++ b/tests/components/dashboard-view.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import { DashboardView } from '@/components/interview/dashboard-view';
+
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+jest.mock('date-fns', () => ({
+  format: () => 'Mar 7, 2026',
+}));
+
+const mockInterviews = [
+  {
+    id: '1',
+    participant_name: 'Alice',
+    topic: 'Marketplace for tutors',
+    target_user: 'students',
+    status: 'analyzed',
+    duration_seconds: 600,
+    created_at: '2026-03-07T10:00:00Z',
+    updated_at: '2026-03-07T10:10:00Z',
+  },
+  {
+    id: '2',
+    participant_name: 'Bob',
+    topic: 'SaaS for gyms',
+    target_user: 'gym owners',
+    status: 'active',
+    duration_seconds: null,
+    created_at: '2026-03-06T09:00:00Z',
+    updated_at: '2026-03-06T09:00:00Z',
+  },
+];
+
+describe('DashboardView', () => {
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it('renders empty state when no interviews', () => {
+    render(<DashboardView interviews={[]} />);
+    expect(screen.getByText('No interviews yet')).toBeInTheDocument();
+    expect(screen.getByText(/Start your first Mom Test interview/)).toBeInTheDocument();
+  });
+
+  it('renders New Interview button in empty state', () => {
+    render(<DashboardView interviews={[]} />);
+    const btn = screen.getByRole('button', { name: /Start new interview/i });
+    expect(btn).toBeInTheDocument();
+    btn.click();
+    expect(mockPush).toHaveBeenCalledWith('/interview/new');
+  });
+
+  it('renders interview cards when interviews exist', () => {
+    render(<DashboardView interviews={mockInterviews} />);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Marketplace for tutors')).toBeInTheDocument();
+    expect(screen.getByText('SaaS for gyms')).toBeInTheDocument();
+  });
+
+  it('renders FAB when interviews exist', () => {
+    render(<DashboardView interviews={mockInterviews} />);
+    const fab = screen.getByRole('button', { name: /Start new interview/i });
+    expect(fab).toBeInTheDocument();
+  });
+
+  it('renders status badges correctly', () => {
+    render(<DashboardView interviews={mockInterviews} />);
+    expect(screen.getByText('Analyzed')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+});

--- a/tests/components/interview-card.test.tsx
+++ b/tests/components/interview-card.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from '@testing-library/react';
+import { InterviewCard } from '@/components/interview/interview-card';
+
+// Mock next/navigation
+const mockPush = jest.fn();
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+// Mock date-fns format to avoid timezone issues in CI
+jest.mock('date-fns', () => ({
+  format: () => 'Mar 7, 2026',
+}));
+
+describe('InterviewCard', () => {
+  const defaultProps = {
+    id: 'test-id-1',
+    participantName: 'Jane Doe',
+    topic: 'SaaS for pet owners',
+    status: 'active' as const,
+    durationSeconds: null,
+    createdAt: '2026-03-07T10:00:00Z',
+  };
+
+  beforeEach(() => {
+    mockPush.mockClear();
+  });
+
+  it('renders participant name and topic', () => {
+    render(<InterviewCard {...defaultProps} />);
+    expect(screen.getByText('Jane Doe')).toBeInTheDocument();
+    expect(screen.getByText('SaaS for pet owners')).toBeInTheDocument();
+  });
+
+  it('renders Active badge for active status', () => {
+    render(<InterviewCard {...defaultProps} status="active" />);
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('renders Completed badge for completed status', () => {
+    render(<InterviewCard {...defaultProps} status="completed" />);
+    expect(screen.getByText('Completed')).toBeInTheDocument();
+  });
+
+  it('renders Analyzed badge for analyzed status', () => {
+    render(<InterviewCard {...defaultProps} status="analyzed" />);
+    expect(screen.getByText('Analyzed')).toBeInTheDocument();
+  });
+
+  it('renders formatted date', () => {
+    render(<InterviewCard {...defaultProps} />);
+    expect(screen.getByText('Mar 7, 2026')).toBeInTheDocument();
+  });
+
+  it('renders duration when provided', () => {
+    render(<InterviewCard {...defaultProps} durationSeconds={185} />);
+    expect(screen.getByText('3:05')).toBeInTheDocument();
+  });
+
+  it('does not render duration when null', () => {
+    render(<InterviewCard {...defaultProps} durationSeconds={null} />);
+    expect(screen.queryByText(/:[\d]{2}/)).not.toBeInTheDocument();
+  });
+
+  it('has correct aria-label', () => {
+    render(<InterviewCard {...defaultProps} />);
+    expect(
+      screen.getByRole('button', { name: /Interview with Jane Doe — Active/ })
+    ).toBeInTheDocument();
+  });
+
+  it('navigates to interview page on click for active interviews', () => {
+    render(<InterviewCard {...defaultProps} status="active" />);
+    screen.getByRole('button').click();
+    expect(mockPush).toHaveBeenCalledWith('/interview/test-id-1');
+  });
+
+  it('navigates to report page on click for analyzed interviews', () => {
+    render(<InterviewCard {...defaultProps} status="analyzed" />);
+    screen.getByRole('button').click();
+    expect(mockPush).toHaveBeenCalledWith('/dashboard/test-id-1/report');
+  });
+});


### PR DESCRIPTION
## Summary
- Add `GET /api/interviews` route for fetching user's interviews ordered by `created_at DESC`
- Create `InterviewCard` component with status badges (Active/Completed/Analyzed), date formatting, duration display, and navigation
- Create `DashboardView` with responsive grid (1/2/3 cols), empty state with CTA, and floating "New Interview" button
- Convert dashboard page from client to server component with Supabase data fetching
- Fix `jest.config.js` to support JSX in `.tsx` test files (react-jsx tsconfig override)
- Add 15 smoke tests across 2 test suites (InterviewCard: 10, DashboardView: 5)

Closes #8

## Verification
- Lint: no errors
- Typecheck: clean (frontend + server)
- Tests: 76/76 pass (6 suites)
- Build: frontend + server both succeed

## Test plan
- [x] Verify empty state renders when no interviews exist
- [x] Verify interview cards show participant name, topic, status badge, date, duration
- [x] Verify clicking Active card navigates to `/interview/[id]`
- [x] Verify clicking Analyzed card navigates to `/dashboard/[id]/report`
- [x] Verify responsive grid layout (1/2/3 columns)
- [x] Verify FAB navigates to `/interview/new`
- [x] Verify only authenticated user's interviews are shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)