### PR TITLE
fix: interview flow bugs + delete feature

### DIFF
--- a/app/api/interview/[id]/route.ts
+++ b/app/api/interview/[id]/route.ts
@@ -1,4 +1,4 @@
-// Implements #7: Interview API — GET (fetch) + PATCH (save transcript)
+// Implements #7: Interview API — GET (fetch) + PATCH (save transcript) + DELETE
 import { NextResponse } from 'next/server';
 import { getAuthUser } from '@/lib/auth';
 import { createServerSupabaseClient } from '@/lib/supabase-server';
@@ -32,6 +32,45 @@ export async function GET(_request: Request, { params }: RouteContext) {
     }
 
     return NextResponse.json(data);
+  } catch (err) {
+    if (err instanceof Error && err.message === 'Unauthorized') {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(_request: Request, { params }: RouteContext) {
+  try {
+    const user = await getAuthUser();
+    const supabase = createServerSupabaseClient();
+
+    // Verify ownership
+    const { data: existing, error: fetchError } = await supabase
+      .from('interviews')
+      .select('id, user_id')
+      .eq('id', params.id)
+      .eq('user_id', user.id)
+      .single();
+
+    if (fetchError || !existing) {
+      return NextResponse.json({ error: 'Interview not found' }, { status: 404 });
+    }
+
+    // Delete related records first (foreign key constraints)
+    await supabase.from('insights').delete().eq('interview_id', params.id);
+    await supabase.from('ai_logs').delete().eq('interview_id', params.id);
+
+    const { error: deleteError } = await supabase
+      .from('interviews')
+      .delete()
+      .eq('id', params.id);
+
+    if (deleteError) {
+      return NextResponse.json({ error: 'Failed to delete interview' }, { status: 500 });
+    }
+
+    return NextResponse.json({ success: true });
   } catch (err) {
     if (err instanceof Error && err.message === 'Unauthorized') {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/components/interview/interview-card.tsx
+++ b/components/interview/interview-card.tsx
@@ -1,11 +1,15 @@
 // Implements #8: Interview card for dashboard grid
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { format } from 'date-fns';
-import { Play, CheckCircle, BarChart3, Clock } from 'lucide-react';
+import toast from 'react-hot-toast';
+import { Play, CheckCircle, BarChart3, Clock, Trash2 } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Modal } from '@/components/ui/modal';
 import type { InterviewStatus } from '@/lib/constants';
 
 interface InterviewCardProps {
@@ -39,6 +43,8 @@ export function InterviewCard({
 }: InterviewCardProps) {
   const router = useRouter();
   const config = statusConfig[status];
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const handleClick = () => {
     if (status === 'active') {
@@ -48,44 +54,102 @@ export function InterviewCard({
     }
   };
 
-  return (
-    <Card
-      hover
-      padding="md"
-      onClick={handleClick}
-      role="button"
-      tabIndex={0}
-      aria-label={`Interview with ${participantName} — ${config.label}`}
-      onKeyDown={(e) => {
-        if (e.key === 'Enter' || e.key === ' ') {
-          e.preventDefault();
-          handleClick();
-        }
-      }}
-    >
-      <div className="flex items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <h3 className="font-heading text-base font-semibold text-[var(--text-primary)] truncate">
-            {participantName}
-          </h3>
-          <p className="mt-1 text-sm text-[var(--text-secondary)] font-body line-clamp-2">
-            {topic}
-          </p>
-        </div>
-        <Badge variant={config.variant} icon={config.icon}>
-          {config.label}
-        </Badge>
-      </div>
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    try {
+      const res = await fetch(`/api/interview/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Failed to delete');
+      }
+      toast.success('Interview deleted');
+      setShowDeleteConfirm(false);
+      router.refresh();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to delete interview');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
 
-      <div className="mt-4 flex items-center gap-4 text-xs text-[var(--text-muted)] font-body">
-        <span>{format(new Date(createdAt), 'MMM d, yyyy')}</span>
-        {durationSeconds != null && (
-          <span className="flex items-center gap-1">
-            <Clock className="h-3 w-3" aria-hidden="true" />
-            {formatDuration(durationSeconds)}
-          </span>
-        )}
-      </div>
-    </Card>
+  return (
+    <>
+      <Card
+        hover
+        padding="md"
+        onClick={handleClick}
+        role="button"
+        tabIndex={0}
+        aria-label={`Interview with ${participantName} — ${config.label}`}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleClick();
+          }
+        }}
+      >
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <h3 className="font-heading text-base font-semibold text-[var(--text-primary)] truncate">
+              {participantName}
+            </h3>
+            <p className="mt-1 text-sm text-[var(--text-secondary)] font-body line-clamp-2">
+              {topic}
+            </p>
+          </div>
+          <Badge variant={config.variant} icon={config.icon}>
+            {config.label}
+          </Badge>
+        </div>
+
+        <div className="mt-4 flex items-center justify-between text-xs text-[var(--text-muted)] font-body">
+          <div className="flex items-center gap-4">
+            <span>{format(new Date(createdAt), 'MMM d, yyyy')}</span>
+            {durationSeconds != null && (
+              <span className="flex items-center gap-1">
+                <Clock className="h-3 w-3" aria-hidden="true" />
+                {formatDuration(durationSeconds)}
+              </span>
+            )}
+          </div>
+          <button
+            onClick={(e) => {
+              e.stopPropagation();
+              setShowDeleteConfirm(true);
+            }}
+            className="flex h-7 w-7 items-center justify-center rounded-lg text-[var(--text-muted)] hover:text-red-500 hover:bg-red-500/10 transition-colors duration-200 cursor-pointer"
+            aria-label={`Delete interview with ${participantName}`}
+          >
+            <Trash2 className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </Card>
+
+      <Modal
+        isOpen={showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(false)}
+        title="Delete Interview?"
+        footer={
+          <>
+            <Button variant="ghost" size="sm" onClick={() => setShowDeleteConfirm(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="danger"
+              size="sm"
+              onClick={handleDelete}
+              disabled={isDeleting}
+            >
+              {isDeleting ? 'Deleting...' : 'Delete'}
+            </Button>
+          </>
+        }
+      >
+        <p className="text-sm text-[var(--text-secondary)] font-body">
+          Are you sure you want to delete the interview with <strong>{participantName}</strong>?
+          This will permanently remove the transcript, analysis, and all related data.
+        </p>
+      </Modal>
+    </>
   );
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -14,7 +14,7 @@ export const MAX_INTERVIEW_DURATION_SECONDS = 900;
 export const INTERVIEW_WARNING_SECONDS = 720;
 
 /** Silence timeout in seconds — auto-end after this duration */
-export const SILENCE_TIMEOUT_SECONDS = 10;
+export const SILENCE_TIMEOUT_SECONDS = 20;
 
 /** Transcript speaker identifiers */
 export const TRANSCRIPT_SPEAKER = {

--- a/server/constants.ts
+++ b/server/constants.ts
@@ -5,7 +5,7 @@ export const MAX_INTERVIEW_DURATION_SECONDS = 900;
 export const INTERVIEW_WARNING_SECONDS = 720;
 
 /** Silence timeout in seconds — auto-end after this duration */
-export const SILENCE_TIMEOUT_SECONDS = 10;
+export const SILENCE_TIMEOUT_SECONDS = 20;
 
 /** RMS silence threshold — values below this are considered silence */
 export const RMS_SILENCE_THRESHOLD = 0.01;

--- a/server/gemini-relay.ts
+++ b/server/gemini-relay.ts
@@ -19,6 +19,10 @@ export class GeminiRelay {
   private ws: WebSocket;
   private callbacks: GeminiRelayCallbacks;
   private closed = false;
+  /** Buffer for accumulating AI output transcription fragments */
+  private aiTranscriptBuffer = '';
+  /** Buffer for accumulating user input transcription fragments */
+  private userTranscriptBuffer = '';
 
   constructor(ws: WebSocket, callbacks: GeminiRelayCallbacks) {
     this.ws = ws;
@@ -114,42 +118,57 @@ export class GeminiRelay {
         }
       }
 
-      // Handle turn complete
-      if (serverContent.turnComplete) {
-        this.sendToClient({ type: 'turn_complete' });
-      }
-
-      // Handle interruption
-      if (serverContent.interrupted) {
-        this.sendToClient({ type: 'interrupted' });
-      }
-
-      // Handle output audio transcription (AI speech text)
+      // Handle output audio transcription (AI speech text) — accumulate into buffer
       const outputTranscription = serverContent.outputTranscription as
         | Record<string, unknown>
         | undefined;
       if (outputTranscription?.text) {
-        const text = outputTranscription.text as string;
-        this.sendToClient({ type: 'transcript', text });
-        this.callbacks.onTranscript({
-          speaker: 'ai-transcription',
-          text,
-          timestamp: Date.now(),
-        });
+        this.aiTranscriptBuffer += outputTranscription.text as string;
       }
 
-      // Handle input audio transcription (user speech text from Gemini)
+      // Handle input audio transcription (user speech text from Gemini) — accumulate into buffer
       const inputTranscription = serverContent.inputTranscription as
         | Record<string, unknown>
         | undefined;
       if (inputTranscription?.text) {
-        const text = inputTranscription.text as string;
-        this.callbacks.onTranscript({
-          speaker: 'user',
-          text,
-          timestamp: Date.now(),
-        });
+        this.userTranscriptBuffer += inputTranscription.text as string;
       }
+
+      // Handle turn complete — flush buffered AI transcript as one message
+      if (serverContent.turnComplete) {
+        this.flushTranscriptBuffers();
+        this.sendToClient({ type: 'turn_complete' });
+      }
+
+      // Handle interruption — flush whatever we have so far
+      if (serverContent.interrupted) {
+        this.flushTranscriptBuffers();
+        this.sendToClient({ type: 'interrupted' });
+      }
+    }
+  }
+
+  /** Flushes accumulated transcript buffers as complete messages */
+  private flushTranscriptBuffers(): void {
+    if (this.aiTranscriptBuffer.trim()) {
+      const text = this.aiTranscriptBuffer.trim();
+      this.sendToClient({ type: 'transcript', text });
+      this.callbacks.onTranscript({
+        speaker: 'ai-transcription',
+        text,
+        timestamp: Date.now(),
+      });
+      this.aiTranscriptBuffer = '';
+    }
+
+    if (this.userTranscriptBuffer.trim()) {
+      const text = this.userTranscriptBuffer.trim();
+      this.callbacks.onTranscript({
+        speaker: 'user',
+        text,
+        timestamp: Date.now(),
+      });
+      this.userTranscriptBuffer = '';
     }
   }
 
@@ -163,6 +182,7 @@ export class GeminiRelay {
 
   /** Close the Gemini session */
   async close(): Promise<void> {
+    this.flushTranscriptBuffers();
     this.closed = true;
     if (this.session) {
       try {

--- a/server/session-manager.ts
+++ b/server/session-manager.ts
@@ -253,7 +253,7 @@ export class SessionManager {
     }
   }
 
-  /** Saves final transcript and updates interview status */
+  /** Saves final transcript, updates interview status, then auto-triggers analysis */
   private async saveFinalTranscript(
     session: ActiveSession,
     durationSeconds: number,
@@ -268,6 +268,18 @@ export class SessionManager {
       );
     } catch (err) {
       console.error('[SessionManager] Final save failed:', err);
+      return; // Don't trigger analysis if save failed
+    }
+
+    // Auto-trigger analysis pipeline (fire-and-forget, don't block session end)
+    try {
+      const { analyzeTranscript } = await import('./analysis.js');
+      console.log(`[SessionManager] Starting analysis for: ${session.interviewId}`);
+      analyzeTranscript(session.interviewId)
+        .then(() => console.log(`[SessionManager] Analysis complete: ${session.interviewId}`))
+        .catch((err: unknown) => console.error('[SessionManager] Analysis failed:', err));
+    } catch (err) {
+      console.error('[SessionManager] Failed to start analysis:', err);
     }
   }
 

--- a/tests/components/interview-card.test.tsx
+++ b/tests/components/interview-card.test.tsx
@@ -71,13 +71,20 @@ describe('InterviewCard', () => {
 
   it('navigates to interview page on click for active interviews', () => {
     render(<InterviewCard {...defaultProps} status="active" />);
-    screen.getByRole('button').click();
+    screen.getByRole('button', { name: /Interview with Jane Doe/ }).click();
     expect(mockPush).toHaveBeenCalledWith('/interview/test-id-1');
   });
 
   it('navigates to report page on click for analyzed interviews', () => {
     render(<InterviewCard {...defaultProps} status="analyzed" />);
-    screen.getByRole('button').click();
+    screen.getByRole('button', { name: /Interview with Jane Doe/ }).click();
     expect(mockPush).toHaveBeenCalledWith('/dashboard/test-id-1/report');
+  });
+
+  it('renders delete button', () => {
+    render(<InterviewCard {...defaultProps} />);
+    expect(
+      screen.getByRole('button', { name: /Delete interview with Jane Doe/ })
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- **Transcript buffering**: AI speech now displays as complete sentences instead of word-by-word fragments
- **Auto-analysis trigger**: `analyzeTranscript()` now fires after session ends (was missing — cards stayed "completed" forever)
- **Silence timeout**: Increased from 10s to 20s
- **Delete interviews**: Users can delete any card from dashboard with confirmation modal
- **DELETE API**: `DELETE /api/interview/[id]` with cascade delete of insights + ai_logs

## Test plan
- [x] 104 tests passing
- [x] TypeScript compiles clean
- [ ] Test interview → verify transcript shows sentences, not words
- [ ] Test interview end → verify card transitions to "Analyzed" after refresh
- [ ] Test delete button on dashboard cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)