### PR TITLE
fix: resolve middleware 504 + redeploy Fly relay under new account

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 .next/
 out/
 node_modules/
+**/node_modules/
+**/dist/
 
 # Next.js app source (not needed in relay server image)
 app/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,13 +17,13 @@ jobs:
 
       - name: Deploy to production (main)
         if: github.ref == 'refs/heads/main'
-        run: flyctl deploy --config fly.toml --app digital-entrepreneurs-relay --remote-only
+        run: flyctl deploy --config fly.toml --app digital-entrepreneurs-relay-daiki --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
       - name: Deploy to development (development branch)
         if: github.ref == 'refs/heads/development'
-        run: flyctl deploy --config fly.dev.toml --app digital-entrepreneurs-relay-dev --remote-only
+        run: flyctl deploy --config fly.dev.toml --app digital-entrepreneurs-relay-daiki-dev --remote-only
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 

--- a/fly.dev.toml
+++ b/fly.dev.toml
@@ -1,7 +1,7 @@
 # Fly.io configuration for the Gemini relay server — DEVELOPMENT environment.
 # Deployed automatically on push to the `development` branch via GitHub Actions.
 
-app = "digital-entrepreneurs-relay-dev"
+app = "digital-entrepreneurs-relay-daiki-dev"
 primary_region = "sjc"
 
 [build]

--- a/fly.toml
+++ b/fly.toml
@@ -1,7 +1,7 @@
 # Fly.io configuration for the Gemini relay server — PRODUCTION environment.
 # Deployed automatically on push to the `main` branch via GitHub Actions.
 
-app = "digital-entrepreneurs-relay"
+app = "digital-entrepreneurs-relay-daiki"
 primary_region = "sjc"
 
 [build]

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,13 +25,16 @@ export async function middleware(request: NextRequest) {
     },
   );
 
+  // Use getSession() instead of getUser() to avoid network calls to Supabase
+  // that cause MIDDLEWARE_INVOCATION_TIMEOUT on Vercel Edge Runtime.
+  // Server-side validation with getUser() should be done in pages/API routes.
   const {
-    data: { user },
-  } = await supabase.auth.getUser();
+    data: { session },
+  } = await supabase.auth.getSession();
 
   const isProtected = PROTECTED_PATHS.some((path) => request.nextUrl.pathname.startsWith(path));
 
-  if (isProtected && !user) {
+  if (isProtected && !session) {
     const url = request.nextUrl.clone();
     url.pathname = '/login';
     url.searchParams.set('redirectTo', request.nextUrl.pathname);
@@ -41,7 +44,7 @@ export async function middleware(request: NextRequest) {
   // Redirect authenticated users away from auth pages
   const isAuthPage =
     request.nextUrl.pathname === '/login' || request.nextUrl.pathname === '/signup';
-  if (isAuthPage && user) {
+  if (isAuthPage && session) {
     const url = request.nextUrl.clone();
     url.pathname = '/dashboard';
     return NextResponse.redirect(url);

--- a/middleware.ts
+++ b/middleware.ts
@@ -25,16 +25,15 @@ export async function middleware(request: NextRequest) {
     },
   );
 
-  // Use getSession() instead of getUser() to avoid network calls to Supabase
-  // that cause MIDDLEWARE_INVOCATION_TIMEOUT on Vercel Edge Runtime.
-  // Server-side validation with getUser() should be done in pages/API routes.
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
+  // Use getClaims() to verify the JWT signature locally without a network
+  // round-trip to Supabase. This avoids MIDDLEWARE_INVOCATION_TIMEOUT on Vercel
+  // Edge while still rejecting forged session cookies (unlike getSession()).
+  const { data } = await supabase.auth.getClaims();
+  const isAuthenticated = !!data?.claims;
 
   const isProtected = PROTECTED_PATHS.some((path) => request.nextUrl.pathname.startsWith(path));
 
-  if (isProtected && !session) {
+  if (isProtected && !isAuthenticated) {
     const url = request.nextUrl.clone();
     url.pathname = '/login';
     url.searchParams.set('redirectTo', request.nextUrl.pathname);
@@ -44,7 +43,7 @@ export async function middleware(request: NextRequest) {
   // Redirect authenticated users away from auth pages
   const isAuthPage =
     request.nextUrl.pathname === '/login' || request.nextUrl.pathname === '/signup';
-  if (isAuthPage && session) {
+  if (isAuthPage && isAuthenticated) {
     const url = request.nextUrl.clone();
     url.pathname = '/dashboard';
     return NextResponse.redirect(url);


### PR DESCRIPTION
## Summary

This PR bundles three related fixes needed to make the production-style interview flow work end to end again:

1. **Middleware 504** — replaced `supabase.auth.getUser()` with `supabase.auth.getClaims()` in `middleware.ts`. `getUser()` makes a per-request network call to Supabase that exceeds Vercel Edge Runtime's middleware timeout. `getClaims()` verifies the JWT signature locally via JWKS — no network round-trip, and unlike `getSession()` it actually rejects forged session cookies (addressing the Bugbot finding on commit 56d8c7f)
2. **Relay WebSocket failure** — the prior Fly app (`digital-entrepreneurs-relay.fly.dev`) was no longer reachable (NXDOMAIN), so all `wss://.../ws` connections from the frontend failed. Redeployed the relay under a new Fly account / app name
3. **Docker build context** — fixed a `.dockerignore` bug uncovered during redeploy

## Changes

### Middleware fix
- `middleware.ts`: `getUser()` → `getSession()` (in 56d8c7f) → `getClaims()` (in aee61c1)
- `getClaims()` decodes and verifies the JWT signature locally using the project JWKS — neither makes a network call (so no 504) nor trusts unverified cookie data (so no forged-cookie bypass)
- Defense in depth at the page/API level via `getAuthUser()` / `getUser()` is unchanged

### Docker build context fix
- `.dockerignore`: added `**/node_modules/` and `**/dist/` so `server/node_modules` is excluded recursively (the pattern `node_modules/` only matches the top-level directory). Without this, pnpm symlinks in `server/node_modules` collided with the container's freshly installed modules and the build failed with `cannot copy to non-directory` on `@google/genai`

### Fly relay migration
- `fly.toml`: app → `digital-entrepreneurs-relay-daiki`
- `fly.dev.toml`: app → `digital-entrepreneurs-relay-daiki-dev`
- `.github/workflows/deploy.yml`: `--app` flags updated to match

## Required follow-up after merge

- **Vercel env var** must be updated: `NEXT_PUBLIC_RELAY_SERVER_URL = wss://digital-entrepreneurs-relay-daiki.fly.dev` (no trailing `/ws` — the hook appends it)
- **GitHub Secrets**: `FLY_API_TOKEN` must be rotated to a token issued from the new Fly account (`fly tokens create deploy`) for CI deploys to work
- Fly secrets (`GOOGLE_AI_API_KEY`, `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`) have already been set in the new Fly app via the dashboard

## Test plan

- [x] Local: `pnpm dev` + new `.env.local` → interview starts, AI speaks, transcript shown (verified)
- [x] Local: `tsc --noEmit` passes after `getClaims()` change
- [ ] Vercel preview / production after env var update: same flow works
- [ ] Confirm no 504s on protected routes
- [ ] Confirm forged session cookies are rejected by middleware (Bugbot finding)
- [ ] GitHub Actions deploy succeeds on next push to main (after `FLY_API_TOKEN` rotation)