### PR TITLE
chore(ci): remove redundant Vercel deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,31 +27,6 @@ jobs:
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
 
-  deploy-frontend:
-    name: Deploy Frontend to Vercel
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Deploy to Vercel production (main)
-        if: github.ref == 'refs/heads/main'
-        run: pnpm dlx vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-
-      - name: Deploy to Vercel preview (development branch)
-        if: github.ref == 'refs/heads/development'
-        run: pnpm dlx vercel deploy --token=${{ secrets.VERCEL_TOKEN }}
-        env:
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+  # Frontend (Next.js) is deployed by Vercel's own GitHub integration —
+  # no GitHub Actions step required. Vercel watches push events on the
+  # connected repository and deploys main → Production, other branches → Preview.


### PR DESCRIPTION
## Summary

Vercel's own GitHub integration watches the connected repository and auto-deploys `main` to Production / other branches to Preview. The GitHub Actions `deploy-frontend` job was duplicating that work, and was failing in CI because `VERCEL_TOKEN` / `VERCEL_ORG_ID` / `VERCEL_PROJECT_ID` secrets still point to the teammates Vercel project (not the newly-created one).

Removing the job eliminates:
- CI noise (red X on every push)
- Email notifications for these spurious failures
- Risk that branch protection would later treat this as required

No production behavior changes — Vercel keeps deploying via its own integration.

## Test plan

- [x] Diff inspected; only the `deploy-frontend` job was removed
- [ ] After merge, next push to main shows green CI (only `deploy-relay` runs)
